### PR TITLE
Implement Asset Grouping + Undo/Redo for Groups

### DIFF
--- a/Lucidity/Assets/Scripts/EditorActions/CreateLayerAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/CreateLayerAction.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class CreateLayerAction : EditorAction {
-    public CreateLayerAction (GameObject gameObject) {
-        base.setActionType(ActionType.CreateLayer);
-        base.setGameObject(gameObject);
+    public CreateLayerAction (List<GameObject> relatedObjects) {
+        base.Type = ActionType.CreateLayer;
+        base.RelatedObjects = relatedObjects;
     }
 }

--- a/Lucidity/Assets/Scripts/EditorActions/DeleteLayerAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/DeleteLayerAction.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class DeleteLayerAction : EditorAction {
-    public DeleteLayerAction (GameObject gameObject) {
-        base.setActionType(ActionType.DeleteLayer);
-        base.setGameObject(gameObject);
+    public DeleteLayerAction (List<GameObject> relatedObjects) {
+        base.Type = ActionType.DeleteLayer;
+        base.RelatedObjects = relatedObjects;
     }
 }

--- a/Lucidity/Assets/Scripts/EditorActions/DeleteMapObjectAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/DeleteMapObjectAction.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class DeleteMapObjectAction : EditorAction {
-    public DeleteMapObjectAction (GameObject gameObject) {
-        base.setActionType(ActionType.DeleteMapObject);
-        base.setGameObject(gameObject);
+    public DeleteMapObjectAction (List<GameObject> relatedObjects) {
+        base.Type = ActionType.DeleteMapObject;
+        base.RelatedObjects = relatedObjects;
     }
 }

--- a/Lucidity/Assets/Scripts/EditorActions/EditorAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/EditorAction.cs
@@ -14,23 +14,17 @@ public abstract class EditorAction {
         MoveLayer,
         RenameLayer
     }
-    private ActionType _actionType;
-    private GameObject _gameObject;
+    private ActionType _type;
+    private List<GameObject> _relatedObjects = new List<GameObject>();
 
-    public ActionType getActionType() {
-        return _actionType;
+    public ActionType Type {
+        get { return _type; }
+        set { _type = value; }
     }
 
-    public GameObject getGameObject() {
-        return _gameObject;
+    public List<GameObject> RelatedObjects {
+        get { return _relatedObjects; }
+        set { _relatedObjects = value; }
     }
-
-    public void setActionType(ActionType actionType) {
-        _actionType = actionType;
-    }
-
-    public void setGameObject(GameObject gameObject) {
-        _gameObject = gameObject;
-    } 
 
 }

--- a/Lucidity/Assets/Scripts/EditorActions/MoveLayerAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/MoveLayerAction.cs
@@ -6,9 +6,9 @@ public class MoveLayerAction : EditorAction {
     private int _oldIndex;
     private int _newIndex;
 
-    public MoveLayerAction (GameObject gameObject, int oldIndex, int newIndex) {
-        base.setActionType(ActionType.MoveLayer);
-        base.setGameObject(gameObject);
+    public MoveLayerAction (List<GameObject> relatedObjects, int oldIndex, int newIndex) {
+        base.Type = ActionType.MoveLayer;
+        base.RelatedObjects = relatedObjects;
         _oldIndex = oldIndex;
         _newIndex = newIndex;
     }

--- a/Lucidity/Assets/Scripts/EditorActions/MoveMapObjectAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/MoveMapObjectAction.cs
@@ -6,9 +6,9 @@ public class MoveMapObjectAction : EditorAction {
     private Vector2 _oldPosition;
     private Vector2 _newPosition;
 
-    public MoveMapObjectAction (GameObject gameObject, Vector2 oldPosition, Vector2 newPosition) {
-        base.setActionType(ActionType.MoveMapObject);
-        base.setGameObject(gameObject);
+    public MoveMapObjectAction (List<GameObject> relatedObjects, Vector2 oldPosition, Vector2 newPosition) {
+        base.Type = ActionType.MoveMapObject;
+        base.RelatedObjects = relatedObjects;
         _oldPosition = oldPosition;
         _newPosition = newPosition;
     }

--- a/Lucidity/Assets/Scripts/EditorActions/PaintAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/PaintAction.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 
 public class PaintAction : EditorAction {
-    public PaintAction (GameObject gameObject) {
-        base.setActionType(ActionType.Paint);
-        base.setGameObject(gameObject);
+    public PaintAction (List<GameObject> relatedObjects) {
+        base.Type = ActionType.Paint;
+        base.RelatedObjects = relatedObjects;
     }
 }

--- a/Lucidity/Assets/Scripts/EditorActions/RenameLayerAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/RenameLayerAction.cs
@@ -6,9 +6,9 @@ public class RenameLayerAction : EditorAction {
     private string _oldName;
     private string _newName;
 
-    public RenameLayerAction (GameObject gameObject, string oldName, string newName) {
-        base.setActionType(ActionType.RenameLayer);
-        base.setGameObject(gameObject);
+    public RenameLayerAction (List<GameObject> relatedObjects, string oldName, string newName) {
+        base.Type = ActionType.RenameLayer;
+        base.RelatedObjects = relatedObjects;
         _oldName = oldName;
         _newName = newName;
     }

--- a/Lucidity/Assets/Scripts/EditorActions/ResizeMapObjectAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/ResizeMapObjectAction.cs
@@ -6,9 +6,9 @@ public class ResizeMapObjectAction : EditorAction {
     private Vector2 _oldSize;
     private Vector2 _newSize;
 
-    public ResizeMapObjectAction (GameObject gameObject, Vector2 oldSize, Vector2 newSize) {
-        base.setActionType(ActionType.RotateMapObject);
-        base.setGameObject(gameObject);
+    public ResizeMapObjectAction (List<GameObject> relatedObjects, Vector2 oldSize, Vector2 newSize) {
+        base.Type = ActionType.RotateMapObject;
+        base.RelatedObjects = relatedObjects;
         _oldSize = oldSize;
         _newSize = newSize;
     }

--- a/Lucidity/Assets/Scripts/EditorActions/RotateMapObjectAction.cs
+++ b/Lucidity/Assets/Scripts/EditorActions/RotateMapObjectAction.cs
@@ -6,9 +6,9 @@ public class RotateMapObjectAction : EditorAction {
     private Quaternion _oldRotation;
     private Quaternion _newRotation;
 
-    public RotateMapObjectAction (GameObject gameObject, Quaternion oldRotation, Quaternion newRotation) {
-        base.setActionType(ActionType.RotateMapObject);
-        base.setGameObject(gameObject);
+    public RotateMapObjectAction (List<GameObject> relatedObjects, Quaternion oldRotation, Quaternion newRotation) {
+        base.Type = ActionType.RotateMapObject;
+        base.RelatedObjects = relatedObjects;
         _oldRotation = oldRotation;
         _newRotation = newRotation;
     }

--- a/Lucidity/Assets/Scripts/MapEditorManager.cs
+++ b/Lucidity/Assets/Scripts/MapEditorManager.cs
@@ -16,7 +16,6 @@ public class MapEditorManager : MonoBehaviour {
     public int Count;
 
     void Start() {
-        Debug.Log("This should only run once");
         Count = 1;
         GameObject[] selectableTools = GameObject.FindGameObjectsWithTag("SelectableTool");
         foreach (GameObject tool in selectableTools) {
@@ -34,35 +33,39 @@ public class MapEditorManager : MonoBehaviour {
 
         if (Input.GetMouseButtonDown(0)
                 && AssetButtons[CurrentButtonPressed].Clicked) {
+            List<GameObject> mapObjects = new List<GameObject>();
             for (int i = 0; i < Count; i++) {
-                GameObject mapObject = (GameObject) Instantiate(AssetPrefabs[CurrentButtonPressed],
+                GameObject temp = ((GameObject) Instantiate(AssetPrefabs[CurrentButtonPressed],
                         new Vector3(worldPosition.x + i*2, worldPosition.y, 0),
-                        Quaternion.identity);
-                if (_actions == null) {
+                        Quaternion.identity));
+                if (temp != null) {
+                    mapObjects.Add(temp);
+                }
+            }
+            if (_actions == null) {
                     _actions = new LinkedList<EditorAction>();
-                    _actions.AddFirst(new PaintAction(mapObject));
+                    _actions.AddFirst(new PaintAction(mapObjects));
                     _currentAction = _actions.First;
-                } else {
-                    if (_currentAction != null && _currentAction.Next != null) {
-                        // these actions can no longer be redone
-                        PermanentlyDeleteActions(_currentAction.Next);
-                        LinkedListNode<EditorAction> actionToRemove = _currentAction.Next;
-                        while (actionToRemove != null) {
-                            _actions.Remove(actionToRemove);
-                            actionToRemove = actionToRemove.Next;
-                        }
-                        _actions.AddAfter(_currentAction, new PaintAction(mapObject));
-                        _currentAction = _currentAction.Next;
-                    } else if (_currentAction != null) {
-                        _actions.AddAfter(_currentAction, new PaintAction(mapObject));
-                        _currentAction = _currentAction.Next;
-                    } else if (_currentAction == null && _actions != null) {
-                        // there is only one action and it has been undone
-                        PermanentlyDeleteActions(_actions.First);
-                        _actions.Clear();
-                        _actions.AddFirst(new PaintAction(mapObject));
-                        _currentAction = _actions.First;
+            } else {
+                if (_currentAction != null && _currentAction.Next != null) {
+                    // these actions can no longer be redone
+                    PermanentlyDeleteActions(_currentAction.Next);
+                    LinkedListNode<EditorAction> actionToRemove = _currentAction.Next;
+                    while (actionToRemove != null) {
+                        _actions.Remove(actionToRemove);
+                        actionToRemove = actionToRemove.Next;
                     }
+                    _actions.AddAfter(_currentAction, new PaintAction(mapObjects));
+                    _currentAction = _currentAction.Next;
+                } else if (_currentAction != null) {
+                    _actions.AddAfter(_currentAction, new PaintAction(mapObjects));
+                    _currentAction = _currentAction.Next;
+                } else if (_currentAction == null && _actions != null) {
+                    // there is only one action and it has been undone
+                    PermanentlyDeleteActions(_actions.First);
+                    _actions.Clear();
+                    _actions.AddFirst(new PaintAction(mapObjects));
+                    _currentAction = _actions.First;
                 }
             }
         }
@@ -77,21 +80,29 @@ public class MapEditorManager : MonoBehaviour {
     public void Undo() {
         if (_currentAction != null) {
             EditorAction actionToUndo = _currentAction.Value;
-            switch(actionToUndo.getActionType()) {
+            switch(actionToUndo.Type) {
                 case EditorAction.ActionType.Paint:
-                    actionToUndo.getGameObject().SetActive(false);
+                    foreach (GameObject obj in actionToUndo.RelatedObjects) {
+                        if (obj != null) {
+                            obj.SetActive(false);
+                        }
+                    }
                     break;
                 case EditorAction.ActionType.DeleteMapObject:
-                    actionToUndo.getGameObject().SetActive(true);
+                    foreach (GameObject obj in actionToUndo.RelatedObjects) {
+                        if (obj != null) {
+                            obj.SetActive(true);
+                        }
+                    }
                     break;
                 case EditorAction.ActionType.MoveMapObject:
-                    actionToUndo.getGameObject().transform.position = ((MoveMapObjectAction) actionToUndo).OldPosition;
+                    // TODO: Implement
                     break;
                 case EditorAction.ActionType.ResizeMapObject:
-                    actionToUndo.getGameObject().transform.localScale = ((ResizeMapObjectAction) actionToUndo).OldSize;
+                    // TODO: Implement
                     break;
                 case EditorAction.ActionType.RotateMapObject:
-                    actionToUndo.getGameObject().transform.rotation = ((RotateMapObjectAction) actionToUndo).OldRotation;
+                    // TODO: Implement
                     break;
                 case EditorAction.ActionType.CreateLayer:
                     // TODO: Implement
@@ -125,21 +136,29 @@ public class MapEditorManager : MonoBehaviour {
             }
             
             // EditorAction actionToRedo = _currentAction.Next.Value;
-            switch(actionToRedo.getActionType()) {
+            switch(actionToRedo.Type) {
                 case EditorAction.ActionType.Paint:
-                    actionToRedo.getGameObject().SetActive(true);
+                    foreach (GameObject obj in actionToRedo.RelatedObjects) {
+                        if (obj != null) {
+                            obj.SetActive(true);
+                        }
+                    }
                     break;
                 case EditorAction.ActionType.DeleteMapObject:
-                    actionToRedo.getGameObject().SetActive(false);
+                    foreach (GameObject obj in actionToRedo.RelatedObjects) {
+                        if (obj != null) {
+                            obj.SetActive(false);
+                        }
+                    }
                     break;
                 case EditorAction.ActionType.MoveMapObject:
-                    actionToRedo.getGameObject().transform.position = ((MoveMapObjectAction) actionToRedo).NewPosition;
+                    // TODO: Implement
                     break;
                 case EditorAction.ActionType.ResizeMapObject:
-                    actionToRedo.getGameObject().transform.localScale = ((ResizeMapObjectAction) actionToRedo).NewSize;
+                    // TODO: Implement
                     break;
                 case EditorAction.ActionType.RotateMapObject:
-                    actionToRedo.getGameObject().transform.rotation = ((RotateMapObjectAction) actionToRedo).NewRotation;
+                    // TODO: Implement
                     break;
                 case EditorAction.ActionType.CreateLayer:
                     // TODO: Implement
@@ -170,8 +189,10 @@ public class MapEditorManager : MonoBehaviour {
     /// </summary>
     private void PermanentlyDeleteActions(LinkedListNode<EditorAction> actionToDelete) {
         while (actionToDelete != null) {
-            if (actionToDelete.Value.getActionType() == EditorAction.ActionType.Paint) {
-             Destroy(actionToDelete.Value.getGameObject());
+            if (actionToDelete.Value.Type == EditorAction.ActionType.Paint) {
+                foreach (GameObject obj in actionToDelete.Value.RelatedObjects) {
+                    Destroy(obj);
+                }
             }
             actionToDelete = actionToDelete.Next;
         }
@@ -205,7 +226,6 @@ public class MapEditorManager : MonoBehaviour {
     }
 
     public void ReadCountInput(string s) {
-        Debug.Log("ReadCountInput method");
         Count = int.Parse(s);
         // Restrict input to only be positive
         if (Count < 0) {

--- a/Lucidity/Assets/Scripts/Tools/Tool.cs
+++ b/Lucidity/Assets/Scripts/Tools/Tool.cs
@@ -6,6 +6,7 @@ using UnityEngine.UI;
 public class Tool : MonoBehaviour {
     private MapEditorManager _editor;
     private string _name;
+    private Color _unselected = new Color(48/255f, 49/255f, 52/255f);
 
     void Start() {
         _editor = GameObject.FindGameObjectWithTag("MapEditorManager")
@@ -14,8 +15,10 @@ public class Tool : MonoBehaviour {
     }
 
     void Update() {
-        if (_editor.ToolStatus.ContainsKey(_name) && _editor.ToolStatus[_name]) {
-            gameObject.GetComponent<Button>().Select();
+        if (_editor.ToolStatus.ContainsKey(_name) && _editor.ToolStatus[_name] && gameObject.GetComponent<Image>().color != Color.black) {
+            gameObject.GetComponent<Image>().color = Color.black;
+        } else if (_editor.ToolStatus.ContainsKey(_name) && !_editor.ToolStatus[_name] && gameObject.GetComponent<Image>().color != _unselected) {
+            gameObject.GetComponent<Image>().color = _unselected;
         }
     }
 

--- a/Lucidity/Assets/UI/Screens/MapEditor.unity
+++ b/Lucidity/Assets/UI/Screens/MapEditor.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.37311953, g: 0.38074014, b: 0.3587274, a: 1}
+  m_IndirectSpecularColor: {r: 0.37311915, g: 0.3807396, b: 0.35872662, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:


### PR DESCRIPTION
# Description

This PR allows users to paint multiple assets at a time. It also includes undo/redo for groups and a few fixes to tool switching to allow input fields to work.

Fixes #[LUC-12](https://luciditydev.atlassian.net/browse/LUC-12?atlOrigin=eyJpIjoiMTQ3MGNmMTMzNjhiNDEzNTlmY2RiYWExZDQ3MDNiMTIiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- exploratory testing

# Screenshots/Demos

https://user-images.githubusercontent.com/45607721/215601450-183baa06-7034-4c11-8f49-54f122cda3e6.mov




[LUC-12]: https://luciditydev.atlassian.net/browse/LUC-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ