### PR TITLE
LUC-10 Implement Asset Deletion

### DIFF
--- a/Lucidity/Assets/Scripts/MapEditorManager.cs
+++ b/Lucidity/Assets/Scripts/MapEditorManager.cs
@@ -8,13 +8,14 @@ public class MapEditorManager : MonoBehaviour {
     public List<GameObject> AssetPrefabs;
     public List<GameObject> AssetImage;
     public int CurrentButtonPressed;
-    public static LinkedList<EditorAction> Actions;
-    public static LinkedListNode<EditorAction> CurrentAction;
+    public LinkedList<EditorAction> Actions;
+    public LinkedListNode<EditorAction> CurrentAction;
     public Dictionary<string, bool> ToolStatus = new Dictionary<string, bool>();
     private List<string> _toolKeys = new List<string>();
     public InputField CountInput;
     public int Count;
     private GameObject _selectionMenu;
+    public GameObject SelectionOptions;
     private GameObject _paintingMenu;
     private Vector2 _lastMousePosition;
     public GameObject LastEncounteredObject;
@@ -27,6 +28,7 @@ public class MapEditorManager : MonoBehaviour {
         ShowBrushSizeSlider();
         _paintingMenu = GameObject.Find("Painting Menu");
         _selectionMenu = GameObject.Find("Selection Menu");
+        SelectionOptions = GameObject.FindGameObjectWithTag("SelectionScrollContent");
         _selectionMenu.SetActive(false);
         GameObject[] selectableTools = GameObject.FindGameObjectsWithTag("SelectableTool");
         foreach (GameObject tool in selectableTools) {
@@ -144,7 +146,6 @@ public class MapEditorManager : MonoBehaviour {
             if (CurrentAction.Previous != null) {
                 CurrentAction = CurrentAction.Previous;
             } else {
-                Debug.Log("No previous actions");
                 CurrentAction = null;
             }
         }
@@ -251,6 +252,9 @@ public class MapEditorManager : MonoBehaviour {
             default:
                 _paintingMenu.SetActive(false);
                 _selectionMenu.SetActive(true);
+                if (SelectMapObject.SelectedObject == null) {
+                    SelectionOptions.SetActive(false);
+                }
                 break;
         }
 

--- a/Lucidity/Assets/Scripts/SelectMapObject.cs
+++ b/Lucidity/Assets/Scripts/SelectMapObject.cs
@@ -5,35 +5,39 @@ using UnityEngine.EventSystems;
 
 public class SelectMapObject : MonoBehaviour, IPointerClickHandler {
 
-    private static GameObject _selectedObject;
+    public static GameObject SelectedObject;
     private static Outline _outline;
     private MapEditorManager _editor;
     
     private void Start() {
         _editor = GameObject.FindGameObjectWithTag("MapEditorManager")
-            .GetComponent<MapEditorManager>();
+            .GetComponent<MapEditorManager>();  
     }
 
     public void OnPointerClick(PointerEventData eventData) {
-        _selectedObject = eventData.pointerClick;
+        SelectedObject = eventData.pointerClick;
+
 
         if (_outline) {
             Destroy(_outline);
         }
 
         _editor.ChangeTools("Selection Tool");
+        _editor.SelectionOptions.SetActive(true);
 
-        _outline = _selectedObject.AddComponent<Outline>();
+        _outline = SelectedObject.AddComponent<Outline>();
         _outline.OutlineMode = Outline.Mode.OutlineAll;
         _outline.OutlineColor = Color.red;
         _outline.OutlineWidth = 2f;
     }
 
     public void DeleteMapObject() {
-        _selectedObject.SetActive(false);
+        SelectedObject.SetActive(false);
         Destroy(_outline);
-        List<GameObject> objectsToDelete = new List<GameObject>() {_selectedObject};
-        MapEditorManager.Actions.AddAfter(MapEditorManager.CurrentAction, new DeleteMapObjectAction(objectsToDelete));
-        MapEditorManager.CurrentAction = MapEditorManager.CurrentAction.Next;
+        List<GameObject> objectsToDelete = new List<GameObject>() {SelectedObject};
+        _editor.Actions.AddAfter(_editor.CurrentAction, new DeleteMapObjectAction(objectsToDelete));
+        _editor.CurrentAction = _editor.CurrentAction.Next;
+        SelectedObject = null;
+        _editor.SelectionOptions.SetActive(false);
     }
 }

--- a/Lucidity/Assets/UI/Screens/MapEditor.unity
+++ b/Lucidity/Assets/UI/Screens/MapEditor.unity
@@ -13468,7 +13468,7 @@ GameObject:
   - component: {fileID: 1595012132}
   m_Layer: 5
   m_Name: ScrollContent
-  m_TagString: Untagged
+  m_TagString: SelectionScrollContent
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -14177,6 +14177,7 @@ MonoBehaviour:
   CurrentButtonPressed: 0
   CountInput: {fileID: 885781265}
   Count: 0
+  SelectionOptions: {fileID: 0}
   LastEncounteredObject: {fileID: 0}
   _brushSizeSlider: {fileID: 979449212}
   _brushSizeText: {fileID: 1431803178}

--- a/Lucidity/ProjectSettings/TagManager.asset
+++ b/Lucidity/ProjectSettings/TagManager.asset
@@ -11,6 +11,7 @@ TagManager:
   - SelectionMenu
   - PaintingMenu
   - CollisionObject
+  - SelectionScrollContent
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
# Description

Implemented asset deletion. When a user selects an asset and clicks the delete button, it is hidden from the scene (works with undo/redo).

Fixes [#LUC-10](https://luciditydev.atlassian.net/browse/LUC-10?atlOrigin=eyJpIjoiMmFhMWM3MTZiNjUwNDYzN2FjMGM3MjJjMGRhZTFiNmEiLCJwIjoiaiJ9)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Exploratory testing

# Screenshots/Demos

Please include screenshots, gifs, or demos of your change, if applicable (ie. UI, runtime visual bug fixes, etc).

![LUC-10](https://user-images.githubusercontent.com/50626396/215926565-b5c43974-0e26-4148-91b3-b1440ab036d0.gif)



[LUC-10]: https://luciditydev.atlassian.net/browse/LUC-10?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ