### PR TITLE
Fix Bug with Painting the Same Asset Before and After Switching Tools

### DIFF
--- a/Lucidity/Assets/Scripts/Controllers/AssetController.cs
+++ b/Lucidity/Assets/Scripts/Controllers/AssetController.cs
@@ -35,8 +35,9 @@ public class AssetController : MonoBehaviour {
 
         GameObject parentContainer = GameObject.Find(
             gameObject.transform.parent.name);
-        // Unselect previously selected asset in "Sprites" pane
-        if (_prevParentContainer != null) {
+        // Unselect previously selected asset in "Sprites" panel unless it 
+        // is the same asset as that that is being selected
+        if (_prevParentContainer != null && _prevParentContainer != parentContainer) {
             _prevParentContainer.GetComponentInChildren<AssetController>().UnselectButton();
         }
         // Highlight asset in "Sprites" pane

--- a/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/PaintingTests.cs
+++ b/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/PaintingTests.cs
@@ -189,6 +189,46 @@ public class PaintingTests : MapEditorTests {
 
         Assert.AreEqual(1, MapEditorManager.Layers[0].Count);
         Assert.AreEqual(1, MapEditorManager.Layers[1].Count);
-
     }
+
+    [Test]
+    public void CanPaintTheAssetBeforeAndAfterSwitchingTools() {
+        // this is a regression test; a bug was found where if a user selected an asset and painted 
+        // it, then switched tools, then switched back to paint and tried to paint the same asset,
+        // the user could not paint with that asset
+
+        Assert.IsTrue(Tool.ToolStatus["Brush Tool"]);
+        MapEditorManager editor = GameObject.Find("MapEditorManager")
+            .GetComponent<MapEditorManager>();
+
+        // place the first instance of the fortress asset
+        GameObject.Find("FortressButton").GetComponent<Button>().onClick.Invoke();
+        editor.PaintAtPosition(new Vector2(-100,150));
+        Assert.AreEqual(1, MapEditorManager.MapObjects.Count);
+        
+        // switch to some other tool
+        GameObject.Find("Panning Tool").GetComponent<Button>().onClick.Invoke();
+        Assert.IsTrue(Tool.ToolStatus["Panning Tool"]);
+        Assert.IsFalse(Tool.ToolStatus["Brush Tool"]);
+
+        // switch back to the brush tool
+        GameObject.Find("Brush Tool").GetComponent<Button>().onClick.Invoke();
+        Assert.IsTrue(Tool.ToolStatus["Brush Tool"]);
+        Assert.IsFalse(Tool.ToolStatus["Panning Tool"]);
+        
+        // all asset buttons should be unclicked
+        GameObject[] paintButtons = GameObject.FindGameObjectsWithTag("PaintButton");
+        foreach (GameObject button in paintButtons) {
+            Assert.IsFalse(button.GetComponent<AssetController>().Clicked);
+        }
+
+        // click the fortress button again
+        GameObject.Find("FortressButton").GetComponent<Button>().onClick.Invoke();
+        Assert.IsTrue(GameObject.Find("FortressButton").GetComponent<AssetController>().Clicked);
+
+        // try to paint
+        editor.PaintAtPosition(new Vector2(100,150));
+        Assert.AreEqual(2, MapEditorManager.MapObjects.Count);
+    }
+
 }


### PR DESCRIPTION
# Description

This PR fixes a bug where the user couldn't paint the same asset they most recently had after switching to a different tool and then back to the brush tool. The issue was that that asset button would be selected than unselected right after (all in the same frame) because the asset button selection handler unselects the previous button that was selected, but didn't account for if the user pressed the same button.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- added a regression test (`CanPaintTheSameAssetBeforeAndAfterSwitchingTools`)

# Screenshots/Demos
https://user-images.githubusercontent.com/45607721/222797907-6ce2c31e-e0a2-4ed3-ba86-ce99d9e94f98.mov

<img width="458" alt="image" src="https://user-images.githubusercontent.com/45607721/222798290-7a101196-60d5-4749-a54d-360a7da4ec74.png">

<img width="458" alt="image" src="https://user-images.githubusercontent.com/45607721/222798360-a1952466-c84b-4c6e-ae41-3db8b3b40e6e.png">

(that one test failing is a known failure in a system rn)

