### PR TITLE
LUC-57: Asset Double Collision Colouring Bug

### DIFF
--- a/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/PaintingTests.cs
+++ b/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/PaintingTests.cs
@@ -205,6 +205,7 @@ public class PaintingTests : MapEditorTests {
         yield return null;
         GameObject placedFortress = GameObject.Find("FortressObject(Clone)");
         Assert.AreEqual(1, MapEditorManager.MapObjects.Count);
+        Assert.AreEqual(Color.white, placedFortress.GetComponent<Image>().color);
 
         // place an asset that should collide with the original fortress
         mapEditorManager.PaintAtPosition(new Vector2(3f, 2.5f));


### PR DESCRIPTION
# Description

Added a regression test for the asset double collision colouring bug. Importantly, a fix was seemingly implemented in [LUC-61: Integrate Assets + LUC-58: Asset Stays Outlined Bug](https://github.com/Cameron-Beaulieu/Lucidity/pull/36) by reverting the material without requiring a reference to its previous material.

Fixes #[LUC-57 (Asset Double Collision Colouring Bug)](https://luciditydev.atlassian.net/browse/LUC-57?atlOrigin=eyJpIjoiZGEzZGY5OTA4ZWNiNDU1ZmI5YjUzNGQ4YTBhODZkZDgiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Attempting to replicate the bug
- `PaintingTests.cs`

# Screenshots/Demos

https://user-images.githubusercontent.com/56100185/225414738-58aa86a1-4b83-4f14-931a-2aec7000bf2e.mp4

# Notes

The only thing I can think of as still being problematic is that it doesn't stay with the error material until 0.5 seconds after the second collision occurs (you can see this in the video included above as well).