### PR TITLE
LUC-66: Unable to Place Asset in Area of Undid MapObject

### DIFF
--- a/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/PaintingTests.cs
+++ b/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/PaintingTests.cs
@@ -264,4 +264,27 @@ public class PaintingTests : MapEditorTests {
         editor.PaintAtPosition(new Vector2(100,150));
         Assert.AreEqual(2, MapEditorManager.MapObjects.Count);
     }
+
+    [UnityTest]
+    public IEnumerator CanPaintAssetOnSamePositionAfterUndo() {
+        // paint an asset
+        Assert.Zero(MapEditorManager.MapObjects.Count);
+        PlayModeTestUtil.PaintAnAsset(new Vector2(3f, 2f), "Fortress");
+        Assert.AreEqual(1, MapEditorManager.MapObjects.Count);
+        int placedObjectId = new List<int>(MapEditorManager.MapObjects.Keys)[0];
+        Assert.IsTrue(MapEditorManager.MapObjects[placedObjectId].IsActive);
+
+        // undo the placement
+        Button undoButton = GameObject.Find("Undo").GetComponent<Button>();
+        undoButton.onClick.Invoke();
+        Assert.IsFalse(MapEditorManager.MapObjects[placedObjectId].IsActive);
+        yield return null;
+
+        // paint an asset at that collides with the position of the original asset
+        PlayModeTestUtil.PaintAnAsset(new Vector2(3f, 2.5f), "Tree");
+        yield return new WaitForEndOfFrame();
+        Assert.AreEqual(1, MapEditorManager.MapObjects.Count);
+        Assert.IsNull(GameObject.Find("FortressObject(Clone)"));
+        Assert.IsNotNull(GameObject.Find("TreeObject(Clone)"));
+    }
 }


### PR DESCRIPTION
# Description

Likely previously due to optimization code, which has since been removed. Can no longer reproduce, but included a regression test.

Fixes #[LUC-66 (Unable to Place Asset in Area of Undid MapObject)](https://luciditydev.atlassian.net/browse/LUC-66?atlOrigin=eyJpIjoiNzliNWUyMGY3YTllNGYxZmJhYTYwZjI2Zjg2NjZmNGYiLCJwIjoiaiJ9)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Exploratory testing
- `PaintingTests.cs`

# Screenshots/Demos


https://user-images.githubusercontent.com/56100185/225520005-8a53661e-d751-4260-a136-a531da793dbe.mp4

