### PR TITLE
Fixes asset collision with Action history bug + add regression test

### DIFF
--- a/Lucidity/Assets/Scripts/AssetCollision.cs
+++ b/Lucidity/Assets/Scripts/AssetCollision.cs
@@ -188,6 +188,7 @@ public class AssetCollision : MonoBehaviour {
             MapEditorManager.Layers[MapEditorManager.LayerContainsMapObject(
                 gameObject.GetInstanceID())].Remove(gameObject.GetInstanceID());
             GameObject parent = gameObject.transform.parent.gameObject;
+            MapEditorManager.CurrentAction = MapEditorManager.CurrentAction.Previous;
             Destroy(gameObject);
             Destroy(parent);
         }

--- a/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/ActionsHistoryTests.cs
+++ b/Lucidity/Assets/Scripts/Tests/PlayModeTests/MapEditorTests/ActionsHistoryTests.cs
@@ -30,6 +30,31 @@ public class ActionsHistoryTests : MapEditorTests {
     }
 
     [Test]
+    public void CanUndoAndRedoAssetPlacementAfterCollision() {
+        // This is a regression test for a bug where previously, collisions would be tracked
+        // within the Action history linked list causing there to be "empty nodes" since the
+        // referenced game object would already have been deleted.
+
+        // paint an asset
+        Assert.Zero(MapEditorManager.MapObjects.Count);
+        PlayModeTestUtil.PaintAnAsset(new Vector2(-100, 150), "Fortress");
+        Assert.AreEqual(1, MapEditorManager.MapObjects.Count);
+        int placedObjectId = new List<int>(MapEditorManager.MapObjects.Keys)[0];
+        Assert.IsTrue(MapEditorManager.MapObjects[placedObjectId].IsActive);
+
+        // cause a collision
+        PlayModeTestUtil.PaintAnAsset(new Vector2(-100, 150), "Fortress");
+        Assert.AreEqual(1, MapEditorManager.MapObjects.Count);
+
+        // undo the placement
+        Button undoButton = GameObject.Find("Undo").GetComponent<Button>();
+        undoButton.onClick.Invoke();
+
+        // assert the the paint action was undone and that a empty node did not exist
+        Assert.IsFalse(MapEditorManager.MapObjects[placedObjectId].IsActive);
+    }
+
+    [Test]
     public void CanUndoAndRedoAssetDeletion() {
         // paint an asset
         Assert.Zero(MapEditorManager.Layers[MapEditorManager.CurrentLayer].Count);


### PR DESCRIPTION
# Description

When a collision occurs when painting an asset, the action is removed from the linked list by rolling by CurrentAction.

LUC-93: https://luciditydev.atlassian.net/browse/LUC-93?atlOrigin=eyJpIjoiYjAxNjU3MGM4ZDU2NGUxYjg3N2RiNGE2MWRjNWI4NTgiLCJwIjoiaiJ9

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
![image](https://user-images.githubusercontent.com/61891760/228360919-225aca2a-db78-4fbd-8412-24fc48616bb5.png)

Checked bug using editor 

# Screenshots/Demos


https://user-images.githubusercontent.com/61891760/228361259-15161647-c10f-4a5f-ad53-307a3cf54bf9.mp4

