### PR TITLE
Fix Zoom Bug in Build

### DIFF
--- a/Lucidity/Assets/Scripts/Controllers/MapEditorManager.cs
+++ b/Lucidity/Assets/Scripts/Controllers/MapEditorManager.cs
@@ -453,9 +453,9 @@ public class MapEditorManager : MonoBehaviour {
                                           newGameObject.transform.localPosition.y),  
             new Vector2(parentGameObject.transform.localPosition.x, 
                         parentGameObject.transform.localPosition.y),
-            new Vector3(parentGameObject.transform.localScale.x - Zoom.zoomFactor, 
-                        parentGameObject.transform.localScale.y - Zoom.zoomFactor, 
-                        parentGameObject.transform.localScale.z - Zoom.zoomFactor), 
+            new Vector3(parentGameObject.transform.localScale.x, 
+                        parentGameObject.transform.localScale.y, 
+                        parentGameObject.transform.localScale.z), 
             parentGameObject.transform.rotation, true);
         mapObjectDictionary.Add(newMapObject.Id, newMapObject);
         if (!IdToGameObjectMapping.ContainsKey(newGameObject.GetInstanceID())) {
@@ -714,9 +714,9 @@ public class MapEditorManager : MonoBehaviour {
             mapObject.MapPosition.y, 0);
         newParent.transform.rotation = mapObject.Rotation;
         newGameObject.transform.localScale = 
-            new Vector3(newGameObject.transform.localScale.x + Zoom.zoomFactor, 
-                        newGameObject.transform.localScale.y + Zoom.zoomFactor, 
-                        newGameObject.transform.localScale.z + Zoom.zoomFactor);
+            new Vector3(newGameObject.transform.localScale.x * (Zoom.zoomFactor + 1), 
+                        newGameObject.transform.localScale.y * (Zoom.zoomFactor + 1), 
+                        newGameObject.transform.localScale.z * (Zoom.zoomFactor + 1));
         AddNewMapObject(newGameObject, mapObject.Name, 
                         newParent, newMapObjects, mapObject.PrefabIndex);
         if (!mapObject.IsActive) {

--- a/Lucidity/Assets/Scripts/Data Structures/DynamicBoundingBox.cs
+++ b/Lucidity/Assets/Scripts/Data Structures/DynamicBoundingBox.cs
@@ -71,10 +71,10 @@ public class DynamicBoundingBox : MonoBehaviour {
         obj.transform.localScale /= _dynamicSideLength * AssetOptions.Spread;
         Vector3 offsetPosition = GetOffsetPosition(coordinate, obj.transform.localScale,
                                                    obj.GetComponent<SpriteRenderer>().size);
-        obj.transform.SetLocalPositionAndRotation(offsetPosition, Quaternion.identity);
-        obj.transform.localScale = new Vector3(obj.transform.localScale.x + Zoom.zoomFactor,
-                                               obj.transform.localScale.y + Zoom.zoomFactor,
-                                               obj.transform.localScale.z + Zoom.zoomFactor);
+        obj.transform.SetLocalPositionAndRotation(offsetPosition * (Zoom.zoomFactor + 1), Quaternion.identity);
+        obj.transform.localScale = new Vector3(obj.transform.localScale.x * (Zoom.zoomFactor + 1),
+                                               obj.transform.localScale.y * (Zoom.zoomFactor + 1),
+                                               obj.transform.localScale.z * (Zoom.zoomFactor + 1));
     }
 
     /// <summary>
@@ -97,9 +97,9 @@ public class DynamicBoundingBox : MonoBehaviour {
         dynamicBoundingBox.name = "DynamicBoundingBox";
         dynamicBoundingBox.tag = "DynamicBoundingBox";
         dynamicBoundingBox.transform.localScale =
-            new Vector3(dynamicBoundingBox.transform.localScale.x + Zoom.zoomFactor,
-                        dynamicBoundingBox.transform.localScale.y + Zoom.zoomFactor,
-                        dynamicBoundingBox.transform.localScale.z + Zoom.zoomFactor)
+            new Vector3(dynamicBoundingBox.transform.localScale.x * (Zoom.zoomFactor + 1),
+                        dynamicBoundingBox.transform.localScale.y * (Zoom.zoomFactor + 1),
+                        dynamicBoundingBox.transform.localScale.z * (Zoom.zoomFactor + 1))
                 * _dynamicSideLength * AssetOptions.Spread;
         Destroy(dynamicBoundingBox.GetComponent<SpriteRenderer>());
 

--- a/Lucidity/Assets/Scripts/Libraries/Util.cs
+++ b/Lucidity/Assets/Scripts/Libraries/Util.cs
@@ -43,6 +43,7 @@ public class Util {
         AvatarMovement.AscendTestingInput = false;
         AvatarMovement.DescendTestingInput = false;
         Render3DScene.EscapeTestingInput = false;
+        Zoom.zoomFactor = 0f;
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

This PR fixes a bug in the build where the hover image with a count of more than 1 looked strange when the map was zoomed in. Additionally, this fixes any bugs in the build related to opening a map from a zoomed in map, and opening a map that was saved while zoomed in.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- build testing

# Screenshots/Demos

Please include screenshots, gifs, or demos of your change, if applicable (ie. UI, runtime visual bug fixes, etc).

## Place Asset Groups While Zoomed

https://user-images.githubusercontent.com/45607721/228678393-84090384-79e3-43cc-97a4-5d3b00f783da.mov

## Open a Map that was Saved while Zoomed + Open a Map from a Zoomed in Map

https://user-images.githubusercontent.com/45607721/228678413-20e5afa5-b99c-4d74-8e5b-a9dbed624ffe.mov


