### PR TITLE
LUC-111: Make Dynamic Bounding Box Maintain Fortress Sparsity

### DIFF
--- a/Lucidity/Assets/Prefabs/FortressObject.prefab
+++ b/Lucidity/Assets/Prefabs/FortressObject.prefab
@@ -11,9 +11,9 @@ GameObject:
   - component: {fileID: 5643009079545502606}
   - component: {fileID: 5470440310217384789}
   - component: {fileID: -5554642497729380398}
-  - component: {fileID: 5217160214185162669}
   - component: {fileID: 7593239794344675914}
   - component: {fileID: 1464309367078864531}
+  - component: {fileID: 6674614087817465013}
   m_Layer: 6
   m_Name: FortressObject
   m_TagString: Untagged
@@ -65,32 +65,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cae7c926ab4194342bcafc0f2244576e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!61 &5217160214185162669
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5643009079545502601}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 20.960001, y: 20.960001}
-    newSize: {x: 0.8, y: 0.8}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 1
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.799, y: 0.799}
-  m_EdgeRadius: 0
 --- !u!222 &7593239794344675914
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -129,3 +103,32 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!60 &6674614087817465013
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5643009079545502601}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.4, y: 0.4}
+      - {x: -0.4, y: 0.4}
+      - {x: -0.4, y: -0.4}
+      - {x: 0.4, y: -0.4}

--- a/Lucidity/Assets/Prefabs/HoverFortressObject.prefab
+++ b/Lucidity/Assets/Prefabs/HoverFortressObject.prefab
@@ -10,9 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 4242923788276325787}
   - component: {fileID: -6822136968891346683}
-  - component: {fileID: 2468773953187570182}
   - component: {fileID: 6962972094383587053}
   - component: {fileID: 7816646605830060336}
+  - component: {fileID: 992741615993391859}
   m_Layer: 2
   m_Name: HoverFortressObject
   m_TagString: AssetImage
@@ -52,32 +52,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ad6a243cba4c14142b3a07999b9b9a5b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!61 &2468773953187570182
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4242923788276325788}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 20.960001, y: 20.960001}
-    newSize: {x: 0.8, y: 0.8}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 1
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 0.8, y: 0.8}
-  m_EdgeRadius: 0
 --- !u!222 &6962972094383587053
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -138,3 +112,32 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!60 &992741615993391859
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4242923788276325788}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 20.960001, y: 20.960001}
+    newSize: {x: 0.8, y: 0.8}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 1
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.4, y: 0.4}
+      - {x: -0.4, y: 0.4}
+      - {x: -0.4, y: -0.4}
+      - {x: 0.4, y: -0.4}


### PR DESCRIPTION
# Description

This PR fixes a bug where dynamic bounding box brush functionality did not work as anticipated with the Fortress sprite. All other sprites could be painted in groups in a brush drag across the screen without causing collisions, but Fortress would cause multiple collisions. This was fixed by changing the collider of Fortress from Box Collider 2D to Polygon Collider 2D. Before this, Fortress was the only asset that didn't use a Polygon Collider 2D.

Fixes #[LUC-111](https://luciditydev.atlassian.net/browse/LUC-111)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- exploratory testing
- build testing

# Screenshots/Demos

Please include screenshots, gifs, or demos of your change, if applicable (ie. UI, runtime visual bug fixes, etc).


https://user-images.githubusercontent.com/45607721/229309098-cb95313f-a4a0-4b60-8a3c-f740c93d15ee.mov




[LUC-111]: https://luciditydev.atlassian.net/browse/LUC-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ