### PR TITLE
Fixing bug with spawn point collision upon loading map

### DIFF
--- a/Lucidity/Assets/Scripts/AssetCollision.cs
+++ b/Lucidity/Assets/Scripts/AssetCollision.cs
@@ -70,7 +70,7 @@ public class AssetCollision : MonoBehaviour {
                     && collisionObject.gameObject.GetComponent<Image>() != null
                     && collisionObject.gameObject.tag != "DynamicBoundingBox"
                     && (LayerCollisions.Count == 0 || collisionObject.gameObject.GetInstanceID() 
-                    != LayerCollisions[LayerCollisions.Count -1][0].Id )) {
+                    != LayerCollisions[LayerCollisions.Count -1][0].Id)) {
                     if(!collisionObject.gameObject.GetComponent<Image>().enabled) {
                         collisionObject.gameObject.GetComponent<Image>().enabled = true;
                         collisionObject.gameObject.GetComponent<Image>()


### PR DESCRIPTION
# Description

Fixes an issue where upon loading, assets would collide with the spawn point, causing a block of code to check if it exists within MapObjects, causing errors.

No associated ticket 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactoring
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

![image](https://user-images.githubusercontent.com/61891760/230166815-3a34116e-4e2a-4775-b474-6fe101e96db9.png)

# Screenshots/Demos

 loading truman's map without errors

![image](https://user-images.githubusercontent.com/61891760/230166993-28bb88e4-ffd6-4542-87b5-5fc9f236cf4c.png)
